### PR TITLE
Remove timezone for datediff

### DIFF
--- a/models/intermediate/int_pendo__page_info.sql
+++ b/models/intermediate/int_pendo__page_info.sql
@@ -54,7 +54,7 @@ active_features as (
     from feature
 
     -- give a buffer of a month
-    where {{ dbt_utils.datediff('valid_through', dbt_utils.current_timestamp(), 'day' ) }} <= 30
+    where {{ dbt_utils.datediff('valid_through::TIMESTAMP', dbt_utils.current_timestamp(), 'day' ) }} <= 30
 
     group by 1
 ),


### PR DESCRIPTION
**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package -->

The Fivetran Pendo connector stores `valid_through`/`validThrough` as type `TIMESTAMP WITH TIMEZONE` in Redshift. Convert it to `TIMESTAMP WITH NO TIMEZONE` before calculating a date difference.

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [ ] Yes (please provide breaking change details below.)
- [ ] No  (please provide explanation how the change is non breaking below.)

Not sure.

**Is this PR in response to a previously created Issue**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [x] Yes, #10
- [ ] No

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Other (please provide additional testing details below)

I ran it against my DWH.

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
- [ ] BigQuery
- [x] Redshift
- [ ] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)